### PR TITLE
Block socket 设置 timeout, 网络慢时返回 error code EGAIN, 改成像 EINTR 一样重试处理而不是…

### DIFF
--- a/rtmp.c
+++ b/rtmp.c
@@ -1568,7 +1568,19 @@ WriteN(PILI_RTMP *r, const char *buffer, int n, RTMPError *error)
         RTMP_Log(RTMP_LOGERROR, "%s, PILI_RTMP send error %d, %s, (%d bytes)", __FUNCTION__,
 	      sockerr, strerror(sockerr), n);
 
-        if (sockerr == EINTR && !PILI_RTMP_ctrlC)
+/*
+Specify the receiving or sending timeouts until reporting an error. 
+The argument is a struct timeval. 
+If an input or output function blocks for this period of time, 
+and data has been sent or received, 
+the return value of that function will be the amount of data transferred; 
+if no data has been transferred and the timeout has been reached then -1 is returned 
+with errno set to EAGAIN or EWOULDBLOCK, or EINPROGRESS (for connect(2)) just as if the socket was specified to be nonblocking.
+ If the timeout is set to zero (the default) then the operation will never timeout. 
+ Timeouts only have effect for system calls that perform socket I/O (e.g., read(2), recvmsg(2), send(2), sendmsg(2)); 
+ timeouts have no effect for select(2), poll(2), epoll_wait(2), and so on.
+*/
+        if ((sockerr == EINTR && !PILI_RTMP_ctrlC ) || sockerr == EAGAIN)
             continue;
         
         if (error) {


### PR DESCRIPTION
Block socket 设置 timeout, 网络抖动时返回 error code EGAIN, 改成像 EINTR 一样重试处理而不是立即 close 。
网络太差时，重试多次后，会出现  error code EPIPE ，socket 挂掉。 这时的处理就是 close 。
所以没有加重试次数限制了。
